### PR TITLE
Update action versions to unblock build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.21" # Use the Go version you're developing with
 
@@ -35,7 +35,7 @@ jobs:
           GOOS=windows GOARCH=arm64 go build -o op-secret-manager-windows-arm64.exe .
 
       - name: Upload Release Assets
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binaries
           path: |
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Release Assets
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: binaries
           path: binaries


### PR DESCRIPTION
The release action is also deprecated, might need addressing.